### PR TITLE
Fixed form-elements-edit.jsx

### DIFF
--- a/src/form-elements-edit.jsx
+++ b/src/form-elements-edit.jsx
@@ -43,7 +43,7 @@ export default class FormElementsEdit extends React.Component {
 
   onEditorStateChange(index, property, editorContent) {
 
-    let html = draftToHtml(convertToRaw(editorContent.getCurrentContent())).replace(/<p>/g, '<div>').replace(/<\/p>/g, '</div>');
+    let html = draftToHtml(convertToRaw(editorContent.getCurrentContent())).replace(/<p/g, '<div').replace(/<\/p>/g, '</div>');
     let this_element = this.state.element;
     this_element[property] = html;
 


### PR DESCRIPTION
Earlier, when center aligning the text in a form element, the code would break because the tags were not replacing currently. This change should fix that.